### PR TITLE
File execution

### DIFF
--- a/src-canary/jycraft/plugin/canary/MainPlugin.java
+++ b/src-canary/jycraft/plugin/canary/MainPlugin.java
@@ -6,6 +6,8 @@ import jycraft.plugin.interpreter.PyContext;
 import net.canarymod.plugin.Plugin;
 import org.python.util.InteractiveInterpreter;
 
+import java.io.File;
+
 public class MainPlugin extends Plugin implements JyCraftPlugin{
 	
 	public MainPlugin() {
@@ -41,6 +43,20 @@ public class MainPlugin extends Plugin implements JyCraftPlugin{
 				return false;
 			}
 			return interpreter.runsource(code);
+		} catch (Throwable e) {
+			throw new Exception(e);
+		} finally {
+			PyContext.setPlugin(null);
+		}
+	}
+	public boolean parse(InteractiveInterpreter interpreter, File script, boolean exec) throws Exception {
+		try {
+			PyContext.setPlugin(this);
+			if (exec){
+				interpreter.execfile(script.getAbsolutePath());
+				return false;
+			}
+			return interpreter.runsource(script.getAbsolutePath());
 		} catch (Throwable e) {
 			throw new Exception(e);
 		} finally {

--- a/src-common/jycraft/plugin/ConsolePlugin.java
+++ b/src-common/jycraft/plugin/ConsolePlugin.java
@@ -15,17 +15,16 @@ public class ConsolePlugin {
             Thread t = new Thread(server);
             t.start();
         }
-        loadPythonPlugins("./python-plugins");
-        // if a port has been specified, it has to be greater than 0
-        if (staticserveport > -1){
+        if (staticserveport > -1){ // if a port has been specified, it has to be greater than 0
             // new file server instance
             PySFListener WsServerListener = new PySFListener(mainPlugin, serverpass);
             StaticFilesSever filesServer = new StaticFilesSever(staticserveport,staticserverootdir, staticservedir, WsServerListener);
             filesServer.start();
         }
+        loadPythonPlugins(mainPlugin, "./python-plugins");
     }
 
-    private static void loadPythonPlugins(String path) {
+    private static void loadPythonPlugins(final JyCraftPlugin mainPlugin, String path) {
         File pluginsDir = new File(path);
         if (!pluginsDir.exists() || !pluginsDir.isDirectory())
             return;
@@ -36,8 +35,12 @@ public class ConsolePlugin {
                 @Override
                 public void run() {
                     PyInterpreter interpreter = new PyInterpreter();
-                    interpreter.execfile(file.getAbsolutePath());
-                    interpreter.close();
+                    try {
+                        mainPlugin.parse(interpreter, file, true);
+                    } catch (Exception e) {
+                        mainPlugin.log("[Python] Exception while loading plugins");
+                        mainPlugin.log("[Python] " + e.toString());
+                    }
                 }
             };
             pyPlugin.start();

--- a/src-common/jycraft/plugin/JyCraftPlugin.java
+++ b/src-common/jycraft/plugin/JyCraftPlugin.java
@@ -2,8 +2,11 @@ package jycraft.plugin;
 
 import org.python.util.InteractiveInterpreter;
 
+import java.io.File;
+
 public interface JyCraftPlugin {
     void log(String message);
 
     boolean parse(InteractiveInterpreter interpreter, String code, boolean exec) throws Exception;
+    boolean parse(InteractiveInterpreter interpreter, File script, boolean exec) throws Exception;
 }

--- a/src-common/jycraft/plugin/impl/FileRunnable.java
+++ b/src-common/jycraft/plugin/impl/FileRunnable.java
@@ -1,0 +1,59 @@
+package jycraft.plugin.impl;
+
+import jycraft.plugin.JyCraftPlugin;
+import jycraft.plugin.interpreter.PyContext;
+import org.python.core.PyException;
+import org.python.util.InteractiveInterpreter;
+
+import java.io.File;
+
+/**
+ * Created by scyth on 1/8/2016.
+ */
+public class FileRunnable implements Runnable {
+    private final JyCraftPlugin plugin;
+    private final boolean exec;
+    private final InteractiveInterpreter interpreter;
+    private final File script;
+    private final TaskResult result;
+
+
+    public FileRunnable(JyCraftPlugin plugin, InteractiveInterpreter interpreter, File script, boolean exec) {
+        this.plugin = plugin;
+        this.exec = exec;
+        this.script = script;
+        this.result = new TaskResult();
+        this.interpreter = interpreter;
+    }
+
+
+    @Override
+    public void run() {
+        try {
+            PyContext.setPlugin(this.plugin);
+            if (exec) {
+                interpreter.execfile(this.script.getAbsolutePath());
+            }
+        } catch (PyException e){
+            result.exception = e;
+        } finally {
+            PyContext.setPlugin(null);
+            synchronized (result){
+                result.done = true;
+                result.notifyAll();
+            }
+        }
+    }
+
+    public boolean more() throws InterruptedException, PyException{
+        synchronized (result) {
+            while (!result.done) {
+                result.wait();
+            }
+        }
+        // if an exception occurs in the main thread throw it on the web-socket thread
+        if(result.exception != null)
+            throw result.exception;
+        return result.more;
+    }
+}

--- a/src-common/jycraft/plugin/impl/FileRunnable.java
+++ b/src-common/jycraft/plugin/impl/FileRunnable.java
@@ -7,9 +7,6 @@ import org.python.util.InteractiveInterpreter;
 
 import java.io.File;
 
-/**
- * Created by scyth on 1/8/2016.
- */
 public class FileRunnable implements Runnable {
     private final JyCraftPlugin plugin;
     private final boolean exec;

--- a/src-common/jycraft/plugin/json/Message.java
+++ b/src-common/jycraft/plugin/json/Message.java
@@ -8,6 +8,8 @@ public class Message {
     protected String command;
     protected String password;
     protected String result;
+    protected String filePath;
+
     private static final RuntimeTypeAdapterFactory<Message> adapter =
             RuntimeTypeAdapterFactory.of(Message.class);
     private static final HashSet<Class<?>> registeredClasses= new HashSet<Class<?>>();
@@ -80,10 +82,20 @@ public class Message {
         this.command = command;
     }
 
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String flePath) {
+        this.filePath = flePath;
+    }
+
     @Override
     public String toString(){
         String s;
         s = "{\"type\":\"" + this.type + "\", \"status\":\"\"" + this.status + "\"\", \"command\":\""+ this.command +"\"}";
         return  s;
     }
+
+
 }

--- a/src-common/jycraft/plugin/servers/PySFListener.java
+++ b/src-common/jycraft/plugin/servers/PySFListener.java
@@ -162,6 +162,8 @@ public class PySFListener implements HttpWebSocketServerListener {
 
                 try{
                    script = new File(System.getProperty("user.dir").concat("/" + filePath));
+                    if (!script.exists() || !script.isDirectory())
+                        return;
                    getPlugin().parse(fileInterpreter, script, true);
                 }
                 catch (Exception e){

--- a/src-common/jycraft/plugin/servers/PySFListener.java
+++ b/src-common/jycraft/plugin/servers/PySFListener.java
@@ -230,10 +230,14 @@ public class PySFListener implements HttpWebSocketServerListener {
         private WebSocket ws;
         private String buffer;
         private Gson gson;
+        private Status status;
+        private Message OSMessage;
         public SFLOutputStream(WebSocket ws){
             this.ws = ws;
             this.buffer = "";
             this.gson = GsonUtils.getGson();
+            status = new Status(100, "Sending result");
+            OSMessage = new Message("result", status);
         }
 
         @Override
@@ -242,17 +246,13 @@ public class PySFListener implements HttpWebSocketServerListener {
             write(bytes, 0, bytes.length);
         }
         public void write(int[] bytes, int offset, int length) {
-            Status status;
-            Message jsonMessage;
             String s = new String(bytes, offset, length);
             this.buffer += s;
             if (this.buffer.endsWith("\n")) {
-        // TODO: 15/12/15 FIX IllegalArgumentException types and labels must be unique while instatinating jsonmessage
-                status = new Status(100, "Sending result");
-                jsonMessage = new Message("interactive", status);
-                jsonMessage.setResult(this.buffer);
-                ws.send(this.gson.toJson(jsonMessage));
                 plugin.log("[Python] "+this.buffer.substring(0, this.buffer.length()-1));
+                OSMessage.setResult(this.buffer);
+                ws.send(this.gson.toJson(OSMessage));
+                // FIXME: Exception while registering a new class in type adapter types and labels must be unique
                 buffer = "";
             }
         }

--- a/src-common/jycraft/plugin/servers/PySFListener.java
+++ b/src-common/jycraft/plugin/servers/PySFListener.java
@@ -148,7 +148,6 @@ public class PySFListener implements HttpWebSocketServerListener {
                 }
                 break;
             case FILE:
-
                 if (!auth) {
                     status = new Status(501, "Not authenticated");
                     loginMessage = new Message("login", status);
@@ -160,13 +159,14 @@ public class PySFListener implements HttpWebSocketServerListener {
                 Message fileExmessage;
                 boolean success = true;
                 final File script;
+
                 try{
-                   script = new File(filePath);
-                    more = getPlugin().parse(fileInterpreter, script, true);
+                   script = new File(System.getProperty("user.dir").concat("/" + filePath));
+                   getPlugin().parse(fileInterpreter, script, true);
                 }
                 catch (Exception e){
                     success = false;
-                    plugin.log("[Python] " + e.getLocalizedMessage());
+                    plugin.log("[Python] " + e.toString());
                     status = new Status(3, "Python Exception");
                     fileExmessage = new Message("file", status);
                     webSocket.send(this.gson.toJson(fileExmessage));

--- a/src-spigot/jycraft/plugin/spigot/MainPlugin.java
+++ b/src-spigot/jycraft/plugin/spigot/MainPlugin.java
@@ -3,10 +3,13 @@ package jycraft.plugin.spigot;
 import jycraft.plugin.ConsolePlugin;
 import jycraft.plugin.JyCraftPlugin;
 
+import jycraft.plugin.impl.FileRunnable;
 import jycraft.plugin.impl.TaskRunnable;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.python.util.InteractiveInterpreter;
+
+import java.io.File;
 
 public class MainPlugin extends JavaPlugin implements JyCraftPlugin {
 
@@ -36,6 +39,17 @@ public class MainPlugin extends JavaPlugin implements JyCraftPlugin {
 			}
 		} ;
 		// run the python code on main thread
+		r.runTask(this);
+		return runnable.more();
+	}
+	public boolean parse(final InteractiveInterpreter interpreter, final File script, final boolean exec) throws Exception {
+		final FileRunnable runnable = new FileRunnable(this, interpreter, script, exec);
+		BukkitRunnable r = new BukkitRunnable() {
+			@Override
+			public void run() {
+				runnable.run();
+			}
+		};
 		r.runTask(this);
 		return runnable.more();
 	}

--- a/src-sponge/jycraft/plugin/sponge/SpongePlugin.java
+++ b/src-sponge/jycraft/plugin/sponge/SpongePlugin.java
@@ -85,4 +85,12 @@ public class SpongePlugin implements JyCraftPlugin {
                 .submit(this);
         return runnable.more();
     }
+    public boolean parse(InteractiveInterpreter interpreter, File script, boolean exec) throws Exception {
+        final FileRunnable runnable = new FileRunnable(this, interpreter, script, exec);
+        game.getScheduler().createTaskBuilder()
+                .name("Python script runner")
+                .execute(t -> runnable.run())
+                .submit(this);
+        return runnable.more();
+    }
 }


### PR DESCRIPTION
Added file execution support with plugin context (canary, spigot, sponge)
the python files must be in the minecraft's server directory or under to be able to run

server
|---- plugins
|---- logs
|---- script.py
L--- jycraft-plugins ------ script.py (or)

and sent  over json in a string like this (**No Leading slash**):

``` javascript
ws.send('{"type":"file", "filePath":"script.py"}');
```

or

``` javascript
ws.send('{"type":"file", "filePath":"jycraft-plugins/script.py"}');
```

the above is useful when editing python files from the web-based editor and sending the location for live execution,

Also, added the posibility to load python files from the server's start
server
|---- plugins
|---- logs
|---- script.py
|---  jycraft-plugins
L--- python-plugins ------ `<any amount of .py files here>`

![execfiles](https://cloud.githubusercontent.com/assets/8684875/12289623/d2766904-b999-11e5-8eac-46f30730ad97.PNG)

the above screenshot was obtained with a script like this

``` python
from org.bukkit import Bukkit

SERVER  = Bukkit.getServer()
WORLD   = SERVER.getWorlds().get(0)

print(WORLD, SERVER)
print("HELLO")
```

asuming that you have plugins that already work you can just load them from the start with the new changes.
